### PR TITLE
Fix bug casuing elements to become stuck as readonly or disabled (when MVC form used).

### DIFF
--- a/Rules/Actions/Client/ChangingFieldHideCurrentField.cs
+++ b/Rules/Actions/Client/ChangingFieldHideCurrentField.cs
@@ -42,7 +42,7 @@ namespace Morph.Forms.Rules.Actions.Client
     {
       if (this.model != null)
       {
-        return "$(this).closest('.form-group').hide();$(this).prop('disabled', 'true')";
+        return "$(this).closest('.form-group').hide();$(this).prop('disabled', true)";
       }
       return  "$(this).parent().parent().hide();";
     }

--- a/Rules/Actions/Client/ChangingFieldShowCurrentField.cs
+++ b/Rules/Actions/Client/ChangingFieldShowCurrentField.cs
@@ -40,7 +40,7 @@ namespace Morph.Forms.Rules.Actions.Client
     {
       if (this.model != null)
       {
-        return "$(this).closest('.form-group').show();$(this).prop('disabled', 'false')";
+        return "$(this).closest('.form-group').show();$(this).prop('disabled', false)";
       }
       return "$(this).parent().parent().show();";
     }

--- a/Rules/Actions/Client/ChangingFieldsHideCurrentField.cs
+++ b/Rules/Actions/Client/ChangingFieldsHideCurrentField.cs
@@ -48,7 +48,7 @@ namespace Morph.Forms.Rules.Actions.Client
     {
       if (this.model != null)
       {
-        return "$(this).closest('.form-group').hide();$(this).prop('disabled', 'true')";
+        return "$(this).closest('.form-group').hide();$(this).prop('disabled', true)";
       }
       return "$(this).parent().parent().hide();";
     }

--- a/Rules/Actions/Client/ChangingFieldsShowCurrentField.cs
+++ b/Rules/Actions/Client/ChangingFieldsShowCurrentField.cs
@@ -39,7 +39,7 @@ namespace Morph.Forms.Rules.Actions.Client
     {
       if (this.model != null)
       {
-        return "$(this).closest('.form-group').show();$(this).prop('disabled', 'false')";
+        return "$(this).closest('.form-group').show();$(this).prop('disabled', false)";
       }
 
       return "$(this).parent().parent().show();";

--- a/Rules/Actions/Client/DisableElement.cs
+++ b/Rules/Actions/Client/DisableElement.cs
@@ -53,7 +53,7 @@
         return null;
       }
 
-      return "$('{0}').prop('disabled', 'true');".FormatWith(selector);
+      return "$('{0}').prop('disabled', true);".FormatWith(selector);
     }
 
     #endregion

--- a/Rules/Actions/Client/SetReadOnly.cs
+++ b/Rules/Actions/Client/SetReadOnly.cs
@@ -57,7 +57,7 @@ namespace Morph.Forms.Rules.Actions.Client
         return null;
       }
 
-      return "$('{0}').prop('readonly', 'true');".FormatWith(selector);
+      return "$('{0}').prop('readonly', true);".FormatWith(selector);
     }
 
     /// <summary>


### PR DESCRIPTION
Bug caused by using strings instead of boolean values when setting the property value via .prop().