### PR TITLE
Handle urls with query string values in the inline js.

### DIFF
--- a/JsCode/InlineJs.cs
+++ b/JsCode/InlineJs.cs
@@ -38,7 +38,7 @@
     /// <summary>
     /// The safe script wrapping
     /// </summary>
-    public static readonly string SafeScriptWrapping = "<script type=\"text/javascript\">(function($){{  var rules=function() {{ {0} }};rules();$(document).ajaxSuccess(function(e, xhr, o, d) {{if (o.url.indexOf('form/Index?wffm') > 0) {{ $=jQuery;rules(); }} }})}})(window.$scw || jQuery);</script>";
+    public static readonly string SafeScriptWrapping = "<script type=\"text/javascript\">(function($){{  var rules=function() {{ {0} }};rules();$(document).ajaxSuccess(function(e, xhr, o, d) {{ var urlIndex = o.url.indexOf('form/Index'); if (urlIndex > 0 && (o.url.indexOf('?wffm', urlIndex) > 0 || o.url.indexOf('&wffm', urlIndex) > 0)) {{ $=jQuery;rules(); }} }})}})(window.$scw || jQuery);</script>";
     
   }
 }


### PR DESCRIPTION
When a page with an ajax MVC form is submitted and the url has a query string parameter, the SafeScriptWrapping does not properly re-execute the rules post-ajaxsuccess.

This is caused by the resulting ajax url being https://hostname/form/index?query=string&wffm.xyz instead of https://hostname/form/index?wffm.xyz .  To fix this I added a check first for the url to contain form/Index and then to contain either ?wffm or &wffm at some point later in the url.